### PR TITLE
Support the executable from Zoom Platform / add tips on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The game is pretty old and unfortunately there is not support high resolution an
 
 If your `eracer.exe` is not running at all, try to set execution compatibility with `Windows XP SP3`.
 
+e-Racer is not good at handling non-native full-screen resolutions. If e-Racer crashes at startup, setting the same resolution to the display and your `eracer.exe` may help.
+
+Even higher resolution than 1920x1200 (for example, 2560x1440) can be configured with this tool, but it is likely to fail to initialize DirectX.
+
 ## Change resolution of e-Racer via [`eracer-config`](https://github.com/Fenex/eracer-config/releases):
 
 Run `eracer-config` without any arguments to see current settings of the game.

--- a/src/patch/items.rs
+++ b/src/patch/items.rs
@@ -44,6 +44,28 @@ impl Patch for PatchEN_992 {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone)]
+pub(super) struct Patch_Zoom;
+
+impl Patch for Patch_Zoom {
+    fn name(&self) -> &'static str {
+        "Zoom Platform 992 KB"
+    }
+
+    fn sha2(&self) -> &'static [u8; 32] {
+        &[
+            0x5E, 0x04, 0xA6, 0x30, 0x4C, 0x4F, 0xBE, 0xBD, 0xE4, 0x66, 0xC3, 0x8C, 0xF4, 0xD5,
+            0xBB, 0xE6, 0xF2, 0xD3, 0xFD, 0xC6, 0x21, 0xAF, 0x2F, 0xDA, 0xA3, 0xB9, 0xCD, 0x24,
+            0xFE, 0xBE, 0x20, 0x35,
+        ]
+    }
+
+    fn ratio_offset(&self) -> usize {
+        0x000CAEFC
+    }
+}
+
 // #[cfg(test)]
 // mod test {
 //     use std::{

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -84,10 +84,10 @@ fn get_patch_by_binary<R: Read>(reader: &mut R) -> Option<(Box<dyn Patch>, [u8; 
         .find(Option::is_some)?
 }
 
-const PATCHES_COUNT: usize = 2;
+const PATCHES_COUNT: usize = 3;
 
 fn get_all_patches() -> [Box<dyn Patch>; PATCHES_COUNT] {
-    [Box::new(items::PatchRU_1008), Box::new(items::PatchEN_992)]
+    [Box::new(items::PatchRU_1008), Box::new(items::PatchEN_992), Box::new(items::Patch_Zoom)]
 }
 
 pub trait Patch {


### PR DESCRIPTION
Hi, thank you for creating this tool more than 20 years after the release of the game. I can't believe that I'm playing e-Racer on my Mac with Windows 11 VM, with a support of higher resolution compared to measly 800x600 lol

# Changes

The change I made here are the following:
 - Addition of a hash of executable distributed by [Zoom Platform](https://www.zoom-platform.com/product/e-racer). The size of the binary is 992KB as you already mentioned in the README, but the slight difference in the exe makes the hash different.
 - Add tips I found to run e-Racer without problem on my machines listed below.

# Confirmed environments

- MacBook Pro (2021, 14-inch), Parallels Desktop 18 for Mac, Windows 11 VM (arm64), highest resolution with success: 1920x1080
- Native Windows PC with Windows 11 Home 22H2, highest resolution with success: 1920x1200